### PR TITLE
Update Whitelist.scala

### DIFF
--- a/src/main/scala/Whitelist.scala
+++ b/src/main/scala/Whitelist.scala
@@ -39,6 +39,9 @@ object Whitelist {
     "ecomfe",
     "mozilla",
     "spine",
-    "jez"
+    "jez",
+    "haskell",
+    "coreos",
+    "scotty-web"
   ).map(_.toLowerCase)
 }


### PR DESCRIPTION
Adds: haskell, CoreOS, and Scotty-web project
