### PR TITLE
Update Whitelist.scala to add Creative Commons

### DIFF
--- a/src/main/scala/Whitelist.scala
+++ b/src/main/scala/Whitelist.scala
@@ -44,6 +44,8 @@ object Whitelist {
     "coreos",
     "scotty-web",
     "vishnuravi",
-    "cimpress-mcp"
+    "cimpress-mcp",
+    "creativecommons",
+    "cc-archive"
   ).map(_.toLowerCase)
 }


### PR DESCRIPTION
Adding creativecommons.

cc-archive is our repo for code that's no longer in use. 
